### PR TITLE
Allow read access to new db users on a specific schema 

### DIFF
--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -8,15 +8,16 @@ require_relative 'utils'
 class Etl
   include Utils
 
-  attr_reader :app, :etl_db_url, :origin_db_url, :config_path, :metabase_username
+  attr_reader :app, :etl_db_url, :origin_db_url, :config_path, :metabase_username, :schema_reader_username
 
-  def initialize(app:, etl_db_url:, origin_db_url:, config_path:, metabase_username:)
+  def initialize(app:, etl_db_url:, origin_db_url:, config_path:, metabase_username:, schema_reader_username: nil)
     @app = app
 
     @etl_db_url = etl_db_url
     @origin_db_url = origin_db_url
     @config_path = config_path
     @metabase_username = metabase_username
+    @schema_reader_username = schema_reader_username
   end
 
   def run
@@ -96,6 +97,10 @@ class Etl
     run_sql_command %(SELECT clone_schema('public', '#{target_schema}', TRUE);)
     run_sql_command %(GRANT USAGE ON SCHEMA #{target_schema} TO #{metabase_username};)
     run_sql_command %(GRANT SELECT ON ALL TABLES IN SCHEMA #{target_schema} TO #{metabase_username};)
+    if schema_reader_username
+      run_sql_command %(GRANT USAGE ON SCHEMA #{target_schema} TO #{schema_reader_username};)
+      run_sql_command %(GRANT SELECT ON ALL TABLES IN SCHEMA #{target_schema} TO #{schema_reader_username};)
+    end
     run_sql_script 'clean_public_schema.sql'
   ensure
     ActiveRecord::Base.connection_handler.clear_all_connections!

--- a/main.rb
+++ b/main.rb
@@ -25,6 +25,14 @@ begin
     "rdvsp" => "RDV_SERVICE_PUBLIC_DB_URL"
   }
 
+  # unlike metabase_username which has access to all schemas, each schema reader is a db user that
+  # only has access to its own schema
+  schema_reader_username_list = {
+    "rdvi" => "RDV_INSERTION_SCHEMA_READER_USERNAME",
+    "rdvs" => "RDV_SOLIDARITES_SCHEMA_READER_USERNAME",
+    "rdvsp" => "RDV_SERVICE_PUBLIC_SCHEMA_READER_USERNAME"
+  }
+
   app = ENV["APP"]
   from_cron = false
   dry_run = false
@@ -81,12 +89,13 @@ begin
   origin_db_url = ENV[origin_db_url_env_var]
   etl_db_url = ENV[etl_db_url_env_var]
   metabase_username = ENV[metabase_username_env_var]
+  schema_reader_username = ENV[schema_reader_username_list[app]] if schema_reader_username_list.key?(app)
 
   if dry_run
     puts "pretend working…"
     sleep 2
   else
-    Etl.new(app:, etl_db_url:, origin_db_url:, config_path:, metabase_username:).run
+    Etl.new(app:, etl_db_url:, origin_db_url:, config_path:, metabase_username:, schema_reader_username:).run
   end
 
   sentry_monitor_helper.capture_end_successful if from_cron

--- a/tests/test_etl.rb
+++ b/tests/test_etl.rb
@@ -2,25 +2,34 @@ require "minitest/autorun"
 require_relative "../lib/etl"
 
 class TestEtl < Minitest::Test
+  ETL_DB_URL = "postgresql://localhost/rdv_sp_etl_test_target"
+  CONFIG_PATH = File.expand_path("config.yml", File.dirname(__FILE__))
+  SEEDS_DUMP_PATH = File.expand_path("seeds_dump.pgsql", File.dirname(__FILE__))
+
+  def teardown
+    ActiveRecord::Base.connection_handler.clear_all_connections!
+  end
+
   def setup
     system "dropdb --if-exists rdv_sp_etl_test_source"
     system "dropdb --if-exists rdv_sp_etl_test_target"
     system "dropuser --if-exists rdv_sp_etl_metabase_user"
+    system "dropuser --if-exists rdvs_schema_reader_user"
 
     system "createdb rdv_sp_etl_test_source"
     # pg_dump --format tar --clean --no-privileges postgresql://localhost/lapin_development -f ../rdv-service-public-etl/tests/seeds_dump.pgsql
-    seeds_dump_path = File.expand_path("seeds_dump.pgsql", File.dirname(__FILE__))
-    system "pg_restore --no-owner -d postgresql://localhost/rdv_sp_etl_test_source #{seeds_dump_path}"
+    system "pg_restore --no-owner -d postgresql://localhost/rdv_sp_etl_test_source #{SEEDS_DUMP_PATH}"
     system "createdb rdv_sp_etl_test_target"
     system %Q(echo "CREATE ROLE rdv_sp_etl_metabase_user WITH LOGIN PASSWORD 'metabase_password'" | psql -d rdv_sp_etl_test_target;)
+    system %Q(echo "CREATE ROLE rdvs_schema_reader_user WITH LOGIN PASSWORD 'reader_password'" | psql -d rdv_sp_etl_test_target;)
   end
 
   def test_something
     Etl.new(
       app: "rdvs",
-      etl_db_url: "postgresql://localhost/rdv_sp_etl_test_target",
+      etl_db_url: ETL_DB_URL,
       origin_db_url: "postgresql://localhost/rdv_sp_etl_test_source",
-      config_path: File.expand_path("config.yml", File.dirname(__FILE__)),
+      config_path: CONFIG_PATH,
       metabase_username: "rdv_sp_etl_metabase_user"
     ).run
 
@@ -31,5 +40,22 @@ class TestEtl < Minitest::Test
     assert_equal users_rows[0]["first_name"], "[valeur unique anonymisée #{users_rows[0]["id"]}]"
     assert_equal users_rows[1]["first_name"], "[valeur unique anonymisée #{users_rows[1]["id"]}]"
     assert_equal users_rows[0]["created_through"], "user_sign_up" # colonne ENUM
+  end
+
+  def test_schema_reader_has_access_when_declared
+    Etl.new(
+      app: "rdvs",
+      etl_db_url: ETL_DB_URL,
+      origin_db_url: "postgresql://localhost/rdv_sp_etl_test_source",
+      config_path: CONFIG_PATH,
+      metabase_username: "rdv_sp_etl_metabase_user",
+      schema_reader_username: "rdvs_schema_reader_user"
+    ).run
+
+    ActiveRecord::Base.establish_connection "postgresql://rdvs_schema_reader_user:reader_password@localhost/rdv_sp_etl_test_target"
+    users_rows = ActiveRecord::Base.connection.execute(
+      Arel::Table.new("rdvs.users").project(:id).to_sql
+    )
+    assert users_rows.count > 0
   end
 end


### PR DESCRIPTION
## Contexte

Côté rdv-insertion on aimerait donner un accès en lecture à notre base de données anonymisée à l'équipe data du GIP. 
L'idée est qu'ils puissent récupérer ces données via un tunnel ssh pour faire de l'analyse de données.
Pour cela il faut:
* créer un nouvel user sur la BDD postgres de l'ETL 
* donner accès aux tables du schema "rdvi" à cet user

Pour le premier pas il suffit de le faire depuis l'interface Postgres de Scalingo.
Les changements de cette PR gère le second pas qui consiste à donner les bons accès à cet user.

## Implémentation

J'ai fait une implémentation générique qui permet d'ajouter les droits à un nouvel user pour chacune des 3 apps.
Pour cela il suffit d'ajouter le nom du user créé en db dans une variable d'environnement `APP_NAME_SCHEMA_READER_USERNAME`.
Pour chacune des app, si cette variable d'environnement est renseignée, alors un nouvel argument `schema_reader_username` est passé à la classe `Etl`. Ainsi si cette argument est passé la méthode `Etl#run` donnera accès aux tables du schéma en question à cet usager.